### PR TITLE
feat: 「すべてのメモを削除」ボタンを追加

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -62,7 +62,7 @@ describe('Home Component', () => {
     expect(screen.getAllByText('新しいメモ')[1]).toBeInTheDocument();
 
     // 2. Delete the memo
-    const deleteButton = screen.getByRole('button', { name: /削除/ });
+    const deleteButton = screen.getByRole('button', { name: '削除' });
     fireEvent.click(deleteButton);
 
     // Ensure the memo is deleted and the initial message is back
@@ -91,5 +91,34 @@ describe('Home Component', () => {
 
     // Check if the title in the sidebar is also updated
     expect(screen.getByText('Updated Title')).toBeInTheDocument();
+  });
+
+  test('deletes all memos when "すべてのメモを削除" button is clicked', () => {
+    // Mock window.confirm
+    const confirmSpy = jest.spyOn(window, 'confirm');
+    confirmSpy.mockImplementation(() => true);
+
+    render(<Home />);
+
+    // 1. Create two memos
+    const newMemoButton = screen.getByRole('button', { name: /新しいメモ/ });
+    fireEvent.click(newMemoButton);
+    fireEvent.click(newMemoButton);
+
+    // Ensure memos are created (we'll have multiple '新しいメモ' texts)
+    expect(screen.getAllByText('新しいメモ').length).toBeGreaterThan(2);
+
+    // 2. Click the delete all button
+    const deleteAllButton = screen.getByRole('button', { name: /すべてのメモを削除/ });
+    fireEvent.click(deleteAllButton);
+
+    // 3. Assertions
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(screen.queryByText('新しいメモ', { selector: 'span' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /すべてのメモを削除/ })).not.toBeInTheDocument();
+    expect(screen.getByText('メモを選択するか、新しいメモを作成してください。')).toBeInTheDocument();
+
+    // Clean up spy
+    confirmSpy.mockRestore();
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,6 +48,14 @@ export default function Home() {
     }
   };
 
+  // すべてのメモを削除する関数
+  const handleDeleteAllMemos = () => {
+    if (window.confirm("本当にすべてのメモを削除しますか？この操作は取り消せません。")) {
+      setMemos([]);
+      setActiveMemoId(null);
+    }
+  };
+
   // アクティブなメモの内容が変更されたときにmemos配列を更新する関数
   const handleMemoChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
@@ -97,6 +105,15 @@ export default function Home() {
             ))}
           </ul>
         </div>
+
+        {memos.length > 0 && (
+          <button
+            onClick={handleDeleteAllMemos}
+            className="w-full bg-red-600 text-white font-bold py-2 px-4 rounded hover:bg-red-800 mt-4"
+          >
+            すべてのメモを削除
+          </button>
+        )}
       </aside>
 
       {/* メインコンテンツ */}


### PR DESCRIPTION
一度にすべてのメモを削除できる機能を追加します。

- サイドバーに「すべてのメモを削除」ボタンを追加
- ボタンはメモが1つ以上存在する場合にのみ表示
- 誤操作によるデータ損失を防ぐため、削除の前に確認ダイアログを表示
- 対応するテストケースを追加し、既存テストの不具合を修正